### PR TITLE
Install archive keyring with eos-keyring

### DIFF
--- a/debian/eos-keyring.install
+++ b/debian/eos-keyring.install
@@ -1,5 +1,7 @@
+etc/apt/trusted.gpg.d
 usr/share/ostree/trusted.gpg.d
 usr/share/eos-app-manager
 usr/share/keyrings/eos-master-keyring.gpg
 usr/share/keyrings/eos-ostree-keyring.gpg
 usr/share/keyrings/eos-apps-keyring.gpg
+usr/share/keyrings/eos-archive-keyring.gpg


### PR DESCRIPTION
This will add eos-archive-keyring.gpg to apt's trusted gpg directory.

[endlessm/eos-shell#4749]
