### PR TITLE
Set eos-keyring priority to important

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,11 +1,12 @@
 Source: eos-keyring
 Priority: extra
-Section: utils
+Section: misc
 Maintainer: Endless Maintainers <maintainers@endlessm.com>
 Build-Depends: debhelper (>= 8), gnupg
 Standards-Version: 3.9.3
 
 Package: eos-keyring
+Priority: important
 Architecture: all
 Depends: gpgv, ${misc:Depends}
 Recommends: gnupg


### PR DESCRIPTION
Ensure that eos-keyring gets installed by debootstrap by marking it as
important. This matches what debian and ubuntu do for their keyring
packages. Also change the section to misc like they do.

[endlessm/eos-shell#5089]
