### PR TITLE
Remove old eos-app-manager keyring

### DIFF
--- a/debian/eos-keyring.install
+++ b/debian/eos-keyring.install
@@ -1,6 +1,4 @@
 etc/apt/trusted.gpg.d
-usr/share/eos-app-manager
-usr/share/keyrings/eos-apps-keyring.gpg
 usr/share/keyrings/eos-archive-keyring.gpg
 usr/share/keyrings/eos-codecs-keyring.gpg
 usr/share/keyrings/eos-flatpak-keyring.gpg


### PR DESCRIPTION
This is not used anymore.

https://phabricator.endlessm.com/T13119