### PR TITLE
Add endless-ca-cert package with Endless CA root cert

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,3 +24,19 @@ Recommends: gnupg
 Description: GnuPG keys for EOS developrs
  This package contains the EOS image signing keys. It was previously
  named eos-dev-keyring.
+
+Package: endless-ca-cert
+Architecture: all
+# Newer dpkg required for activate-noawait support per deb-triggers(5)
+Pre-Depends: dpkg (>= 1.16.1)
+Depends: ${misc:Depends}, ca-certificates
+Enhances: ca-certificates
+Description: Endless CA root certificate
+ This package contains the root certificate for the Endless SSL
+ certificate authority (CA). This CA provides SSL certificates for
+ internal Endless services.
+ .
+ Installing this package will add it to the system's trusted certificate
+ authorities. You may need to run "dpkg-reconfigure ca-certificates" to
+ enable endless/endless-ca.crt if you've previously installed and
+ removed this package.

--- a/debian/endless-ca-cert.install
+++ b/debian/endless-ca-cert.install
@@ -1,0 +1,1 @@
+usr/share/ca-certificates/endless/

--- a/debian/endless-ca-cert.triggers
+++ b/debian/endless-ca-cert.triggers
@@ -1,0 +1,1 @@
+activate-noawait update-ca-certificates


### PR DESCRIPTION
Provide the Endless SSL CA root certificate in the endless-ca-cert
package. The certificate will be added to the system's trusted CA
certificates by triggering update-ca-certificates. The setup here is
based on the ca-cacert package.

If endless/endless-ca.crt was previously installed and removed (it was
temporarily in the main ca-certificates package), then "dpkg-reconfigure
ca-certificates" may need to be run to re-enable it.

https://phabricator.endlessm.com/T18743