### PR TITLE
More Endless CA packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,11 +8,15 @@ Standards-Version: 3.9.3
 Package: eos-keyring
 Priority: important
 Architecture: all
-Depends: gpgv, ${misc:Depends}
+Depends: ca-certificates, gpgv, libnss3-tools, openssl, ${misc:Depends}
 Recommends: gnupg
 Description: GnuPG keys for EOS
-  This package contains signing keys for EOS including ostree updates, apt repos
-  and any other deliverables
+ This package contains signing keys for EOS including ostree updates,
+ apt repos and any other deliverables.
+ .
+ A copy of the Endless SSL CA certificate is included. The
+ endless-ca-trust-system and endless-ca-trust-user scripts can be used
+ for manually trusting it at the system and user levels.
 
 Package: eos-image-keyring
 Provides: eos-dev-keyring

--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,7 @@ Package: endless-ca-cert
 Architecture: all
 # Newer dpkg required for activate-noawait support per deb-triggers(5)
 Pre-Depends: dpkg (>= 1.16.1)
-Depends: ${misc:Depends}, ca-certificates
+Depends: ca-certificates, eos-keyring (= ${binary:Version}), ${misc:Depends}
 Enhances: ca-certificates
 Description: Endless CA root certificate
  This package contains the root certificate for the Endless SSL
@@ -43,4 +43,7 @@ Description: Endless CA root certificate
  Installing this package will add it to the system's trusted certificate
  authorities. You may need to run "dpkg-reconfigure ca-certificates" to
  enable endless/endless-ca.crt if you've previously installed and
- removed this package.
+ removed this package. You will also need to run endless-ca-trust-user
+ to add the certificate to the user's NSS database for chromium and
+ chrome. The /etc/profile.d/endless-ca-trust-user.sh profile script does
+ this automatically at login.

--- a/debian/endless-ca-cert.install
+++ b/debian/endless-ca-cert.install
@@ -1,1 +1,2 @@
+etc/profile.d/endless-ca-trust-user.sh
 usr/share/ca-certificates/endless/

--- a/debian/endless-ca-cert.postinst
+++ b/debian/endless-ca-cert.postinst
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+CONF_FILE=/etc/ca-certificates.conf
+CONF_FILE_NEW="${CONF_FILE}.dpkg-new"
+CONF_FILE_OLD="${CONF_FILE}.dpkg-old"
+CA_CONF=endless/endless-ca.crt
+
+if [ "$1" = "configure" ]; then
+    # Add the CA cert to the configuration file if there's no existing
+    # declaration
+    if [ -f "$CONF_FILE" ]; then
+        if grep -q "^!\?${CA_CONF}$" "$CONF_FILE"; then
+            cp "$CONF_FILE" "$CONF_FILE_NEW"
+            echo "$CA_CONF" >> "$CONF_FILE_NEW"
+            mv -f "$CONF_FILE" "$CONF_FILE_OLD"
+            mv "$CONF_FILE_NEW" "$CONF_FILE"
+        fi
+    fi
+fi
+
+# Substitute debhelper actions
+#DEBHELPER#
+
+# Ensure successful exit per
+# https://www.debian.org/doc/debian-policy/#exit-status
+exit 0

--- a/debian/endless-ca-cert.postrm
+++ b/debian/endless-ca-cert.postrm
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -e
+
+CONF_FILE=/etc/ca-certificates.conf
+CONF_FILE_NEW="${CONF_FILE}.dpkg-new"
+CONF_FILE_OLD="${CONF_FILE}.dpkg-old"
+CA_CONF=endless/endless-ca.crt
+
+if [ "$1" = "purge" ]; then
+    # Remove the CA cert declaration from the configuration file
+    if [ -f "$CONF_FILE" ]; then
+        if grep -q "^!\?${CA_CONF}$" "$CONF_FILE"; then
+            cp "$CONF_FILE" "$CONF_FILE_NEW"
+            sed -i "\,^!\?${CA_CONF}$,d" "$CONF_FILE_NEW"
+            mv -f "$CONF_FILE" "$CONF_FILE_OLD"
+            mv "$CONF_FILE_NEW" "$CONF_FILE"
+        fi
+    fi
+fi
+
+# Substitute debhelper actions
+#DEBHELPER#
+
+# Ensure successful exit per
+# https://www.debian.org/doc/debian-policy/#exit-status
+exit 0

--- a/debian/eos-keyring.install
+++ b/debian/eos-keyring.install
@@ -1,4 +1,6 @@
 etc/apt/trusted.gpg.d
+usr/bin/endless-ca-trust-system
+usr/bin/endless-ca-trust-user
 usr/share/eos-keyring/endless-ca.crt
 usr/share/keyrings/eos-archive-keyring.gpg
 usr/share/keyrings/eos-codecs-keyring.gpg

--- a/debian/eos-keyring.install
+++ b/debian/eos-keyring.install
@@ -1,4 +1,5 @@
 etc/apt/trusted.gpg.d
+usr/share/eos-keyring/endless-ca.crt
 usr/share/keyrings/eos-archive-keyring.gpg
 usr/share/keyrings/eos-codecs-keyring.gpg
 usr/share/keyrings/eos-flatpak-keyring.gpg


### PR DESCRIPTION
Package the scripts from #29 and provide maintainer scripts for the endless-ca-cert package so it gets added to `/etc/ssl/certs` without user intervention in normal cases.

https://phabricator.endlessm.com/T18743