### PR TITLE
endless-ca-cert.postinst: Fix inverted logic

### DIFF
--- a/debian/endless-ca-cert.postinst
+++ b/debian/endless-ca-cert.postinst
@@ -11,7 +11,7 @@ if [ "$1" = "configure" ]; then
     # Add the CA cert to the configuration file if there's no existing
     # declaration
     if [ -f "$CONF_FILE" ]; then
-        if grep -q "^!\?${CA_CONF}$" "$CONF_FILE"; then
+        if ! grep -q "^!\?${CA_CONF}$" "$CONF_FILE"; then
             cp "$CONF_FILE" "$CONF_FILE_NEW"
             echo "$CA_CONF" >> "$CONF_FILE_NEW"
             mv -f "$CONF_FILE" "$CONF_FILE_OLD"


### PR DESCRIPTION
The line is supposed to be added if the pattern was not found in the
existing configuration file.

https://phabricator.endlessm.com/T18743