### PR TITLE
Add eos-infra-keyring package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,6 +29,14 @@ Description: GnuPG keys for EOS developrs
  This package contains the EOS image signing keys. It was previously
  named eos-dev-keyring.
 
+Package: eos-infra-keyring
+Architecture: all
+Depends: gpgv, ${misc:Depends}
+Recommends: gnupg
+Description: GnuPG keys for Endless infrastucture repository
+ This package contains the Endless infrastructure repository signing
+ key. It's only useful on Endless servers.
+
 Package: endless-ca-cert
 Architecture: all
 # Newer dpkg required for activate-noawait support per deb-triggers(5)

--- a/debian/eos-infra-keyring.install
+++ b/debian/eos-infra-keyring.install
@@ -1,0 +1,2 @@
+etc/apt/trusted.gpg.d/eos-infra-archive-keyring.gpg
+usr/share/keyrings/eos-infra-archive-keyring.gpg


### PR DESCRIPTION
This contains the Endless infrastructure repository keyring. It won't
(and shouldn't) be installed on normal EOS systems. The intended use
case is for Endless servers. It's just included here for convenient
reuse of the eos-keyring machinery.

Main branch PR in #33.