### PR TITLE
Don't install infra keyring in eos-keyring

### DIFF
--- a/debian/eos-keyring.install
+++ b/debian/eos-keyring.install
@@ -1,4 +1,4 @@
-etc/apt/trusted.gpg.d
+etc/apt/trusted.gpg.d/eos-archive-keyring.gpg
 usr/bin/endless-ca-trust-system
 usr/bin/endless-ca-trust-user
 usr/share/eos-keyring/endless-ca.crt


### PR DESCRIPTION
Make the match on etc/apt/trusted.gpg.d more specific so that
eos-infra-keyring.gpg doesn't end up in both eos-keyring and
eos-infra-keyring.