### PR TITLE
Add public package archive keyring to apt trusted keys

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -98,7 +98,11 @@ ostree_keyringdir = $(datadir)/ostree/trusted.gpg.d
 ostree_keyring_DATA = $(OSTREE_KEYRING) $(FLATPAK_KEYRING)
 
 archive_keyringdir = $(sysconfdir)/apt/trusted.gpg.d
-archive_keyring_DATA = $(ARCHIVE_KEYRING) $(INFRA_KEYRING)
+archive_keyring_DATA = \
+	$(ARCHIVE_KEYRING) \
+	$(INFRA_KEYRING) \
+	$(PUBARCHIVE_KEYRING) \
+	$(NULL)
 
 $(ALL_KEYRINGS):
 	$(AM_V_GEN)GPG='$(GPG)' $(srcdir)/build-keyring $@ $^


### PR DESCRIPTION
The key in eos-pub-archive-keyring.gpg is now used to sign a public
package archive at deb.endlessos.org. For convenience, add this to apt's
trusted keys just like the key used for the internal repo on obs-master.

https://phabricator.endlessm.com/T31225