### PR TITLE
Install eos-pub-archive-keyring.gpg to apt trusted keys

### DIFF
--- a/debian/eos-keyring.install
+++ b/debian/eos-keyring.install
@@ -1,4 +1,5 @@
 etc/apt/trusted.gpg.d/eos-archive-keyring.gpg
+etc/apt/trusted.gpg.d/eos-pub-archive-keyring.gpg
 usr/bin/endless-ca-trust-system
 usr/bin/endless-ca-trust-user
 usr/share/eos-keyring/endless-ca.crt


### PR DESCRIPTION
This would have been caught or at least reported with a newer debhelper
compat version...

https://phabricator.endlessm.com/T31225