### PR TITLE
test-x509-expiration: Use standard RE check for whitespace

### DIFF
--- a/test-x509-expiration
+++ b/test-x509-expiration
@@ -16,7 +16,7 @@ is_ca_cert() {
     local ca
 
     ca=$(${OPENSSL} x509 -noout -ext basicConstraints -in "${cert}" | \
-        awk -F: '$1 ~ /^\s*CA$/ {print $2}')
+        awk -F: '$1 ~ /^[[:space:]]*CA$/ {print $2}')
     [ "$ca" = TRUE ]
 }
 


### PR DESCRIPTION
The `\s` whitespace shorthand character class is provided by most regex
implementations, but it's not actually part of POSIX REs. Unfortunately,
while `gawk` and `grep` do implement it, `mawk` does not. In that case,
no CA certificates are detected and all certificates are tested against
the 1 year expiration window. Use the standard character class instead.

https://phabricator.endlessm.com/T33537