### PR TITLE
build-keyring: Overwrite target if it exists

### DIFF
--- a/build-keyring
+++ b/build-keyring
@@ -30,4 +30,5 @@ for key in "$@"; do
 done
 
 # Export all the keys to the keyring
+rm -f "${KEYRING}"
 ${GPG} --batch --quiet --export --output "${KEYRING}"


### PR DESCRIPTION
When the target keyring exists but the keys have changed, we need to remove the target keyring before telling gpg to export to it, or else it fails with:

    gpg: key export failed: File exists

https://phabricator.endlessm.com/T35453